### PR TITLE
docs: document hk midfreq stack usage

### DIFF
--- a/hk_midfreq/DEVELOPMENT_PLAN.md
+++ b/hk_midfreq/DEVELOPMENT_PLAN.md
@@ -1,0 +1,62 @@
+# HK Mid-Frequency Strategy Module Development Plan
+
+## 1. Project Setup
+- [x] Create `hk_midfreq/` package to host strategy, backtest, and review tooling.
+- [ ] Add module scaffolding files:
+  - `config.py`
+  - `factor_interface.py`
+  - `strategy_core.py`
+  - `backtest_engine.py`
+  - `review_tools.py`
+  - `__init__.py`
+- [ ] Establish local data access adapters (e.g., wrappers around `MultiTimeframeFactorStore`).
+
+## 2. Factor Integration Layer
+- [ ] Implement `load_factor_scores` to pull top-ranked factors from screening outputs.
+- [ ] Provide helper to fetch aligned OHLCV + factor data for target universe.
+- [ ] Add validation routines (date coverage, liquidity filters).
+
+## 3. Strategy Logic Layer
+- [ ] Build reversal baseline (`hk_reversal_logic`) using vectorbt indicators.
+- [ ] Implement portfolio-level candidate selection via factor scores.
+- [ ] Parameterize strategy behaviors via `config.py` (capital, hold days, costs).
+- [ ] Document extension points for future multi-factor blending.
+
+## 4. Backtest Engine
+- [ ] Deliver single-symbol backtest wrapper using `vbt.Portfolio.from_signals`.
+- [ ] Implement multi-symbol portfolio aggregation and cash management.
+- [ ] Support transaction cost modeling and dynamic position sizing hooks.
+- [ ] Define standardized outputs (performance metrics, trades log, equity curve).
+
+## 5. Review & Reporting Tools
+- [ ] Build summary reporter (key metrics, drawdown, turnover).
+- [ ] Add visualization helpers (equity curve, trade PnL histogram, heatmaps).
+- [ ] Provide export utilities (CSV/JSON) for strategy diagnostics.
+
+## 6. Automation & Testing
+- [ ] Write smoke tests for each module (data loading, signal generation, backtest).
+- [ ] Integrate with existing `make test` workflow (pytest collection inside `hk_midfreq/tests/`).
+- [ ] Add pre-commit formatting hooks to cover new directory.
+
+## 7. Documentation & Examples
+- [ ] Draft README detailing module usage and configuration.
+- [ ] Create `run_example.ipynb` demonstrating end-to-end workflow.
+- [ ] Prepare onboarding checklist for new strategies (multi-symbol support, factor integration).
+
+## 8. Timeline (Suggested)
+| Week | Milestone |
+|------|-----------|
+| 1    | Complete module scaffolding, factor integration layer. |
+| 2    | Implement strategy logic & baseline backtest, add unit tests. |
+| 3    | Finalize review tools, documentation, and notebook demonstration. |
+
+## 9. Dependencies & Coordination
+- Align with `factor_system` outputs; reuse existing configs for data locations.
+- Confirm vectorbt version compatibility with project lockfiles.
+- Coordinate with data engineering to ensure timely Parquet updates for HK symbols.
+
+## 10. Risk & Mitigation
+- **Data latency**: Cache last successful load and expose diagnostics.
+- **Parameter drift**: Centralize config constants and track changes via version control.
+- **Performance bottlenecks**: Use lazy loading and chunked computations when iterating across symbols.
+

--- a/hk_midfreq/README.md
+++ b/hk_midfreq/README.md
@@ -1,0 +1,196 @@
+# HK Mid-Frequency Strategy Stack
+
+This document explains the purpose, architecture, and day-to-day usage of the
+`hk_midfreq` package. It is designed to help you wire the existing factor
+screening outputs into a modular **signal → backtest → review** workflow powered
+by `vectorbt`.
+
+---
+
+## 1. Package Goals
+
+- Provide a thin integration layer between the professional factor screener and
+  live strategy research.
+- Encapsulate the baseline reversal strategy logic so you can iterate without
+  modifying notebooks or ad-hoc scripts.
+- Supply reproducible backtesting helpers and reporting tools for multi-symbol
+  portfolios.
+
+---
+
+## 2. Module Map
+
+| Module | Responsibility |
+| --- | --- |
+| [`config.py`](./config.py) | Dataclasses that store trading, execution, and runtime toggles. |
+| [`factor_interface.py`](./factor_interface.py) | Utilities that read the screener output directory and aggregate factor scores per symbol/timeframe. |
+| [`strategy_core.py`](./strategy_core.py) | Candidate selection and signal generation (RSI + Bollinger + volume reversal). |
+| [`backtest_engine.py`](./backtest_engine.py) | `vectorbt`-based engines for single-asset and portfolio-level simulations. |
+| [`review_tools.py`](./review_tools.py) | Convenience helpers to inspect stats, trades, and charts. |
+| [`__init__.py`](./__init__.py) | Public exports for downstream scripts and notebooks. |
+| [`DEVELOPMENT_PLAN.md`](./DEVELOPMENT_PLAN.md) | Roadmap that tracks open tasks and milestones. |
+
+All modules are importable via `import hk_midfreq as hkm` for a consistent API
+surface.
+
+---
+
+## 3. Data & Directory Expectations
+
+The loader assumes you have already run `ProfessionalFactorScreener` and that
+results live under the directory defined by
+`StrategyRuntimeConfig.base_output_dir` (defaults to `因子筛选/`). Each screening
+session is expected to match the folder layout produced by
+`EnhancedResultManager`:
+
+```
+因子筛选/
+  └── <session_id>/
+        ├── screening_statistics.json
+        ├── executive_summary.txt
+        └── timeframes/
+              ├── 0700.HK_60min/
+              │     └── top_factors_detailed.json
+              └── ...
+```
+
+The strategy layer consumes `top_factors_detailed.json` to compute aggregate
+scores for each symbol. Market OHLCV data should be supplied separately (e.g.,
+via `MultiTimeframeFactorStore` or another loader in your notebooks/scripts).
+
+---
+
+## 4. Configuration Overview
+
+Instantiate a configuration to override defaults when needed:
+
+```python
+from hk_midfreq.config import TradingConfig, ExecutionConfig, StrategyRuntimeConfig
+
+trading_cfg = TradingConfig(capital=2_000_000, max_positions=10)
+execution_cfg = ExecutionConfig(transaction_cost=0.0045, stop_loss=0.02)
+runtime_cfg = StrategyRuntimeConfig(base_output_dir=Path("/path/to/因子筛选"))
+```
+
+Pass these objects into other modules if you need bespoke behavior. Without
+arguments, the defaults encoded in
+`DEFAULT_TRADING_CONFIG` / `DEFAULT_EXECUTION_CONFIG` /
+`DEFAULT_RUNTIME_CONFIG` are used.
+
+---
+
+## 5. Typical Workflow
+
+1. **Discover scores** – Use `FactorScoreLoader` to read the latest screening
+   session and convert the scores into a ranked `Series`.
+2. **Select candidates** – Feed the scores into `StrategyCore.select_candidates`
+   (optionally with universe constraints) to choose the top symbols.
+3. **Generate signals** – Run `StrategyCore.build_signals_for_symbol` for each
+   symbol with the corresponding OHLCV data to obtain `entries`/`exits`.
+4. **Backtest** – Call `run_portfolio_backtest` with a dictionary of per-symbol
+   close prices and signals; obtain a `BacktestArtifacts` bundle containing the
+   `vectorbt.Portfolio` plus metadata.
+5. **Review** – Use functions from `review_tools.py` to print statistics, inspect
+   trades, or render charts.
+
+---
+
+## 6. End-to-End Example
+
+```python
+from pathlib import Path
+
+import pandas as pd
+import vectorbt as vbt
+
+from hk_midfreq import (
+    BacktestArtifacts,
+    FactorScoreLoader,
+    StrategyCore,
+    run_portfolio_backtest,
+)
+
+# 1) Load factor scores (auto-detects latest session under 因子筛选/)
+score_loader = FactorScoreLoader()
+factor_scores = score_loader.load_scores_as_series(["0700.HK", "9988.HK", "3690.HK"])
+
+# 2) Choose candidates
+core = StrategyCore()
+selected = core.select_candidates(factor_scores, top_n=core.trading_config.max_positions)
+
+# 3) Prepare price data (replace with your actual loader)
+price_data: dict[str, pd.Series] = {
+    symbol: load_close_series(symbol)  # user-defined helper
+    for symbol in selected
+}
+volume_data: dict[str, pd.Series] = {
+    symbol: load_volume_series(symbol)
+    for symbol in selected
+}
+
+signals = {}
+for symbol in selected:
+    close = price_data[symbol]
+    volume = volume_data[symbol]
+    signals[symbol] = core.build_signals_for_symbol(close=close, volume=volume)
+
+# 4) Run portfolio backtest
+artifacts: BacktestArtifacts = run_portfolio_backtest(price_data, signals)
+portfolio = artifacts.portfolio
+
+# 5) Inspect results
+portfolio.stats()
+portfolio.trades.records_readable.head()
+portfolio.plot().show()
+```
+
+Replace `load_close_series` / `load_volume_series` with the appropriate data
+retrieval functions (e.g., `MultiTimeframeFactorStore`). All portfolio sizing
+and friction rules default to the values declared in `config.py`.
+
+---
+
+## 7. CLI / Notebook Tips
+
+- When iterating interactively, import the entire namespace via
+  `import hk_midfreq as hkm` to access `hkm.FactorScoreLoader`,
+  `hkm.StrategyCore`, and `hkm.run_portfolio_backtest`.
+- Call `hkm.review_tools.print_summary(portfolio)` or
+  `hkm.review_tools.plot_performance(portfolio)` for quick diagnostics.
+- Use `StrategyCore.update_configs(...)` (if implemented in future extensions)
+  or re-instantiate with custom configs to experiment with alternative position
+  sizing or execution assumptions.
+
+---
+
+## 8. Extending the Stack
+
+- **Additional factors**: Implement new aggregation schemes inside
+  `FactorScoreLoader.load_symbol_scores` (e.g., IC-weighted average).
+- **Alternative strategies**: Subclass `StrategyCore` or add new methods to
+  generate different entry/exit rules while reusing the backtest engines.
+- **Risk overlays**: Modify `run_portfolio_backtest` to supply custom weights,
+  position limits, or stop overlays using the `vectorbt` API.
+- **Reporting**: Expand `review_tools` with monthly breakdowns, factor exposure
+  charts, or CSV export utilities.
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Possible Cause | Resolution |
+| --- | --- | --- |
+| `FileNotFoundError: No screening session directory found.` | `因子筛选/` is empty or lives elsewhere. | Override `StrategyRuntimeConfig.base_output_dir` to point at the correct location. |
+| Empty factor score series | Symbols not present in the selected session. | Confirm screener outputs exist or adjust the symbol universe. |
+| `ValueError: Unsupported aggregation method` | Invalid `agg` parameter. | Choose `mean` or `max`, or extend the loader with your custom method. |
+| Portfolio returns all zeros | Missing entries/exits or misaligned OHLCV indices. | Ensure price/volume series share the same frequency and timezone. |
+
+---
+
+## 10. Related Documents
+
+- [`factor_system/factor_screening/README.md`](../factor_system/factor_screening/README.md)
+  for details on the screener output layout.
+- [`hk_midfreq/DEVELOPMENT_PLAN.md`](./DEVELOPMENT_PLAN.md) for outstanding tasks
+  and roadmap discussions.
+

--- a/hk_midfreq/__init__.py
+++ b/hk_midfreq/__init__.py
@@ -1,0 +1,44 @@
+"""Public exports for the HK mid-frequency strategy package."""
+
+from hk_midfreq import backtest_engine, factor_interface, review_tools, strategy_core
+from hk_midfreq.backtest_engine import (
+    BacktestArtifacts,
+    run_portfolio_backtest,
+    run_single_asset_backtest,
+)
+from hk_midfreq.config import (
+    DEFAULT_EXECUTION_CONFIG,
+    DEFAULT_RUNTIME_CONFIG,
+    DEFAULT_TRADING_CONFIG,
+    ExecutionConfig,
+    StrategyRuntimeConfig,
+    TradingConfig,
+)
+from hk_midfreq.factor_interface import (
+    FactorScoreLoader,
+    SymbolScore,
+    load_factor_scores,
+)
+from hk_midfreq.strategy_core import StrategyCore, StrategySignals, hk_reversal_logic
+
+__all__ = [
+    "backtest_engine",
+    "factor_interface",
+    "review_tools",
+    "strategy_core",
+    "BacktestArtifacts",
+    "run_portfolio_backtest",
+    "run_single_asset_backtest",
+    "DEFAULT_EXECUTION_CONFIG",
+    "DEFAULT_RUNTIME_CONFIG",
+    "DEFAULT_TRADING_CONFIG",
+    "ExecutionConfig",
+    "StrategyRuntimeConfig",
+    "TradingConfig",
+    "FactorScoreLoader",
+    "SymbolScore",
+    "load_factor_scores",
+    "StrategyCore",
+    "StrategySignals",
+    "hk_reversal_logic",
+]

--- a/hk_midfreq/backtest_engine.py
+++ b/hk_midfreq/backtest_engine.py
@@ -1,0 +1,138 @@
+"""Backtesting utilities built on top of vectorbt."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+import vectorbt as vbt
+
+from hk_midfreq.config import (
+    DEFAULT_EXECUTION_CONFIG,
+    DEFAULT_TRADING_CONFIG,
+    ExecutionConfig,
+    TradingConfig,
+)
+from hk_midfreq.strategy_core import StrategySignals
+
+
+@dataclass
+class BacktestArtifacts:
+    """Container holding the generated portfolio and associated metadata."""
+
+    portfolio: vbt.Portfolio
+    signals: Dict[str, StrategySignals]
+
+
+def _position_size_from_prices(
+    close: pd.Series, trading_config: TradingConfig
+) -> pd.Series:
+    """Compute discrete share counts for a single asset."""
+
+    allocation = trading_config.allocation_per_position()
+    quantity = np.floor(allocation / close).replace([np.inf, -np.inf], 0.0)
+    return quantity.fillna(0.0)
+
+
+def run_single_asset_backtest(
+    close: pd.Series,
+    signals: StrategySignals,
+    trading_config: TradingConfig = DEFAULT_TRADING_CONFIG,
+    execution_config: ExecutionConfig = DEFAULT_EXECUTION_CONFIG,
+) -> vbt.Portfolio:
+    """Execute a single-asset backtest using vectorbt."""
+
+    if close.empty:
+        raise ValueError("Close price series is empty")
+
+    entries = signals.entries.reindex(close.index).fillna(False)
+    exits = signals.exits.reindex(close.index).fillna(False)
+    size = _position_size_from_prices(close, trading_config)
+
+    portfolio = vbt.Portfolio.from_signals(
+        close=close,
+        entries=entries,
+        exits=exits,
+        init_cash=trading_config.allocation_per_position(),
+        fees=execution_config.transaction_cost,
+        slippage=execution_config.slippage,
+        size=size,
+        stop_loss=signals.stop_loss,
+        take_profit=signals.take_profit,
+        direction="longonly",
+    )
+    return portfolio
+
+
+def _build_matrix(
+    data: Mapping[str, pd.Series], index: pd.Index, fill_value: float | bool = 0.0
+) -> pd.DataFrame:
+    """Align a mapping of series to a shared index."""
+
+    columns = {}
+    for symbol, series in data.items():
+        columns[symbol] = series.reindex(index).fillna(fill_value)
+    return pd.DataFrame(columns, index=index)
+
+
+def run_portfolio_backtest(
+    price_data: Mapping[str, pd.DataFrame],
+    signals: Mapping[str, StrategySignals],
+    trading_config: TradingConfig = DEFAULT_TRADING_CONFIG,
+    execution_config: ExecutionConfig = DEFAULT_EXECUTION_CONFIG,
+) -> Optional[BacktestArtifacts]:
+    """Run a portfolio backtest for the provided signal map."""
+
+    if not signals:
+        return None
+
+    close_columns: Dict[str, pd.Series] = {}
+    entries_map: Dict[str, pd.Series] = {}
+    exits_map: Dict[str, pd.Series] = {}
+
+    for symbol, signal in signals.items():
+        data = price_data.get(symbol)
+        if data is None or "close" not in data:
+            continue
+        close_series = data["close"].dropna()
+        close_columns[symbol] = close_series
+        entries_map[symbol] = signal.entries
+        exits_map[symbol] = signal.exits
+
+    if not close_columns:
+        return None
+
+    combined_index = pd.Index(
+        sorted(set().union(*[series.index for series in close_columns.values()]))
+    )
+
+    close_df = _build_matrix(close_columns, combined_index)
+    entries_df = _build_matrix(entries_map, combined_index, fill_value=False).astype(
+        bool
+    )
+    exits_df = _build_matrix(exits_map, combined_index, fill_value=False).astype(bool)
+
+    allocation = trading_config.allocation_per_position()
+    size_df = close_df.apply(lambda col: np.floor(allocation / col), axis=0)
+    size_df.replace([np.inf, -np.inf], 0.0, inplace=True)
+    size_df.fillna(0.0, inplace=True)
+
+    portfolio = vbt.Portfolio.from_signals(
+        close=close_df,
+        entries=entries_df,
+        exits=exits_df,
+        init_cash=trading_config.capital,
+        fees=execution_config.transaction_cost,
+        slippage=execution_config.slippage,
+        stop_loss=execution_config.stop_loss,
+        take_profit=execution_config.primary_take_profit(),
+        size=size_df,
+        direction="longonly",
+    )
+
+    return BacktestArtifacts(portfolio=portfolio, signals=dict(signals))
+
+
+__all__ = ["BacktestArtifacts", "run_single_asset_backtest", "run_portfolio_backtest"]

--- a/hk_midfreq/config.py
+++ b/hk_midfreq/config.py
@@ -1,0 +1,55 @@
+"""Configuration objects for the HK mid-frequency strategy stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_TAKE_PROFITS = (0.006, 0.01, 0.014, 0.018)
+
+
+@dataclass(frozen=True)
+class TradingConfig:
+    """Portfolio sizing and holding horizon parameters."""
+
+    capital: float = 1_000_000.0
+    position_size: float = 100_000.0
+    max_positions: int = 8
+    hold_days: int = 4
+
+    def allocation_per_position(self) -> float:
+        """Return the maximum cash allocated to a single position."""
+
+        return min(self.position_size, self.capital / max(self.max_positions, 1))
+
+
+@dataclass(frozen=True)
+class ExecutionConfig:
+    """Trading frictions and stop management settings."""
+
+    transaction_cost: float = 0.0038
+    slippage: float = 0.001
+    stop_loss: float = 0.018
+    take_profit_levels: Sequence[float] = field(
+        default_factory=lambda: DEFAULT_TAKE_PROFITS
+    )
+
+    def primary_take_profit(self) -> float:
+        """Pick the first take-profit level for engines that only support one value."""
+
+        return self.take_profit_levels[0] if self.take_profit_levels else 0.0
+
+
+@dataclass(frozen=True)
+class StrategyRuntimeConfig:
+    """High-level toggles for the HK mid-frequency workflow."""
+
+    strategy_name: str = "HK_MIDFREQ_REVERSAL"
+    base_output_dir: Path = Path("因子筛选")
+    default_timeframe: str = "60min"
+
+
+DEFAULT_TRADING_CONFIG = TradingConfig()
+DEFAULT_EXECUTION_CONFIG = ExecutionConfig()
+DEFAULT_RUNTIME_CONFIG = StrategyRuntimeConfig()

--- a/hk_midfreq/factor_interface.py
+++ b/hk_midfreq/factor_interface.py
@@ -1,0 +1,196 @@
+"""Interfaces to consume screened factor scores for strategy selection."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+
+from hk_midfreq.config import StrategyRuntimeConfig, DEFAULT_RUNTIME_CONFIG
+
+
+@dataclass(frozen=True)
+class SymbolScore:
+    """Aggregated factor score for a single symbol."""
+
+    symbol: str
+    timeframe: str
+    score: float
+    source_session: str
+
+
+class FactorScoreLoader:
+    """Load screened factor scores from enhanced screener outputs."""
+
+    def __init__(
+        self,
+        runtime_config: StrategyRuntimeConfig = DEFAULT_RUNTIME_CONFIG,
+        session_id: Optional[str] = None,
+    ) -> None:
+        self._config = runtime_config
+        self._session_id = session_id
+
+    def list_sessions(self) -> List[Path]:
+        """Return all available screening sessions sorted by recency."""
+
+        if not self._config.base_output_dir.exists():
+            return []
+
+        sessions = [p for p in self._config.base_output_dir.iterdir() if p.is_dir()]
+        sessions.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+        return sessions
+
+    def resolve_session(self) -> Optional[Path]:
+        """Resolve the directory containing screening artifacts."""
+
+        if self._session_id is not None:
+            target = self._config.base_output_dir / self._session_id
+            return target if target.exists() else None
+
+        sessions = self.list_sessions()
+        return sessions[0] if sessions else None
+
+    def load_factor_table(
+        self, symbol: str, timeframe: Optional[str] = None, top_n: Optional[int] = None
+    ) -> pd.DataFrame:
+        """Load raw factor rows for ``symbol`` from the selected session."""
+
+        session_dir = self.resolve_session()
+        if session_dir is None:
+            raise FileNotFoundError("No screening session directory found.")
+
+        timeframe_dir = session_dir / "timeframes"
+        if not timeframe_dir.exists():
+            raise FileNotFoundError(
+                f"`timeframes` directory missing under {session_dir}"
+            )
+
+        frames: List[pd.DataFrame] = []
+        for candidate_dir in timeframe_dir.iterdir():
+            if not candidate_dir.is_dir():
+                continue
+            if not candidate_dir.name.startswith(f"{symbol}_"):
+                continue
+            tf = candidate_dir.name.split("_")[1]
+            if timeframe is not None and tf != timeframe:
+                continue
+            top_factors_file = candidate_dir / "top_factors_detailed.json"
+            if not top_factors_file.exists():
+                continue
+            with top_factors_file.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            if not data:
+                continue
+            df = pd.DataFrame(data)
+            df["symbol"] = symbol
+            df["timeframe"] = tf
+            frames.append(df)
+
+        if not frames:
+            raise FileNotFoundError(
+                f"No factor data found for symbol={symbol} timeframe={timeframe}"
+            )
+
+        table = pd.concat(frames, ignore_index=True)
+        table.sort_values(by="rank", inplace=True)
+        if top_n is not None:
+            table = table.head(top_n)
+        return table
+
+    def load_symbol_scores(
+        self,
+        symbols: Iterable[str],
+        timeframe: Optional[str] = None,
+        top_n: int = 5,
+        agg: str = "mean",
+    ) -> List[SymbolScore]:
+        """Aggregate factor scores for a list of symbols."""
+
+        results: List[SymbolScore] = []
+        session_dir = self.resolve_session()
+        session_name = session_dir.name if session_dir is not None else ""
+        for symbol in symbols:
+            try:
+                table = self.load_factor_table(symbol, timeframe=timeframe, top_n=top_n)
+            except FileNotFoundError:
+                continue
+            if table.empty or "comprehensive_score" not in table.columns:
+                continue
+            if agg == "mean":
+                score_value = float(table["comprehensive_score"].mean())
+            elif agg == "max":
+                score_value = float(table["comprehensive_score"].max())
+            else:
+                raise ValueError(f"Unsupported aggregation method: {agg}")
+            results.append(
+                SymbolScore(
+                    symbol=symbol,
+                    timeframe=str(table["timeframe"].iloc[0]),
+                    score=score_value,
+                    source_session=session_name,
+                )
+            )
+        return results
+
+    def scores_to_series(self, scores: Iterable[SymbolScore]) -> pd.Series:
+        """Convert ``SymbolScore`` objects to a descending ``Series``."""
+
+        mapping: Dict[str, float] = {score.symbol: score.score for score in scores}
+        series = pd.Series(mapping, name="factor_score")
+        series.sort_values(ascending=False, inplace=True)
+        return series
+
+    def load_scores_as_series(
+        self,
+        symbols: Iterable[str],
+        timeframe: Optional[str] = None,
+        top_n: int = 5,
+        agg: str = "mean",
+    ) -> pd.Series:
+        """Convenience wrapper to fetch aggregated scores as ``Series``."""
+
+        scores = self.load_symbol_scores(
+            symbols, timeframe=timeframe, top_n=top_n, agg=agg
+        )
+        if not scores:
+            return pd.Series(dtype=float, name="factor_score")
+        return self.scores_to_series(scores)
+
+    def load_all_symbols(
+        self, timeframe: Optional[str] = None, top_n: int = 5, agg: str = "mean"
+    ) -> pd.Series:
+        """Inspect the session folder to load scores for every tracked symbol."""
+
+        session_dir = self.resolve_session()
+        if session_dir is None:
+            return pd.Series(dtype=float, name="factor_score")
+        timeframe_dir = session_dir / "timeframes"
+        if not timeframe_dir.exists():
+            return pd.Series(dtype=float, name="factor_score")
+
+        symbols = {
+            path.name.split("_")[0]
+            for path in timeframe_dir.iterdir()
+            if path.is_dir() and "_" in path.name
+        }
+        return self.load_scores_as_series(
+            symbols, timeframe=timeframe, top_n=top_n, agg=agg
+        )
+
+
+def load_factor_scores(
+    symbols: Iterable[str],
+    timeframe: Optional[str] = None,
+    loader: Optional[FactorScoreLoader] = None,
+    top_n: int = 5,
+    agg: str = "mean",
+) -> pd.Series:
+    """Module-level helper mirroring the original scaffold signature."""
+
+    score_loader = loader or FactorScoreLoader()
+    return score_loader.load_scores_as_series(
+        symbols, timeframe=timeframe, top_n=top_n, agg=agg
+    )

--- a/hk_midfreq/review_tools.py
+++ b/hk_midfreq/review_tools.py
@@ -1,0 +1,40 @@
+"""Post-backtest review helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+import vectorbt as vbt
+
+from hk_midfreq.backtest_engine import BacktestArtifacts
+
+
+def portfolio_statistics(portfolio: vbt.Portfolio) -> pd.Series:
+    """Return a core statistics series from the vectorbt portfolio."""
+
+    return portfolio.stats()
+
+
+def trade_overview(portfolio: vbt.Portfolio, limit: int = 10) -> pd.DataFrame:
+    """Return the top ``limit`` trades in a readable format."""
+
+    return portfolio.trades.records_readable.head(limit)
+
+
+def compile_review(artifacts: BacktestArtifacts, limit: int = 10) -> dict:
+    """Collect statistics and trade summaries for downstream reporting."""
+
+    stats = portfolio_statistics(artifacts.portfolio)
+    trades = trade_overview(artifacts.portfolio, limit=limit)
+    return {"stats": stats, "trades": trades}
+
+
+def print_review(artifacts: BacktestArtifacts, limit: int = 10) -> None:
+    """Pretty-print the review bundle to stdout."""
+
+    review = compile_review(artifacts, limit=limit)
+    print(review["stats"])  # noqa: T201 - human-facing summary output
+    print("=" * 60)
+    print(review["trades"])  # noqa: T201
+
+
+__all__ = ["portfolio_statistics", "trade_overview", "compile_review", "print_review"]

--- a/hk_midfreq/strategy_core.py
+++ b/hk_midfreq/strategy_core.py
@@ -1,0 +1,189 @@
+"""Strategy logic and candidate selection for the HK mid-frequency stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+import vectorbt as vbt
+
+from hk_midfreq.config import (
+    DEFAULT_EXECUTION_CONFIG,
+    DEFAULT_RUNTIME_CONFIG,
+    DEFAULT_TRADING_CONFIG,
+    ExecutionConfig,
+    StrategyRuntimeConfig,
+    TradingConfig,
+)
+from hk_midfreq.factor_interface import FactorScoreLoader
+
+
+@dataclass
+class StrategySignals:
+    """Bundle of entry/exit signals and risk settings for one symbol."""
+
+    symbol: str
+    timeframe: str
+    entries: pd.Series
+    exits: pd.Series
+    stop_loss: float
+    take_profit: float
+
+    def as_dict(self) -> Dict[str, pd.Series | float | str]:
+        """Serialize the signal bundle into a mapping."""
+
+        return {
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "entries": self.entries,
+            "exits": self.exits,
+            "stop_loss": self.stop_loss,
+            "take_profit": self.take_profit,
+        }
+
+
+def _compute_time_based_exits(entries: pd.Series, hold_days: int) -> pd.Series:
+    """Generate exit signals ``hold_days`` bars after each entry."""
+
+    cleaned_entries = entries.fillna(False).astype(bool)
+    exits = pd.Series(False, index=cleaned_entries.index)
+    if hold_days <= 0:
+        return exits
+
+    entry_positions = np.flatnonzero(cleaned_entries.to_numpy())
+    if entry_positions.size == 0:
+        return exits
+
+    exit_positions = entry_positions + hold_days
+    exit_positions = exit_positions[exit_positions < len(cleaned_entries.index)]
+    if exit_positions.size == 0:
+        return exits
+
+    exits.iloc[exit_positions] = True
+    return exits
+
+
+def hk_reversal_logic(
+    close: pd.Series,
+    volume: pd.Series,
+    hold_days: int,
+    rsi_window: int = 14,
+    bb_window: int = 20,
+    volume_window: int = 5,
+    rsi_threshold: float = 30.0,
+    volume_multiplier: float = 1.2,
+) -> StrategySignals:
+    """Generate reversal signals using RSI, Bollinger Bands, and volume confirmation."""
+
+    if close.empty:
+        raise ValueError("Close series cannot be empty")
+
+    aligned_volume = volume.reindex(close.index).fillna(method="ffill")
+
+    rsi = vbt.RSI.run(close, window=rsi_window).rsi
+    bb = vbt.BBANDS.run(close, window=bb_window)
+    rolling_volume = aligned_volume.rolling(
+        window=volume_window, min_periods=volume_window
+    ).mean()
+
+    cond_rsi = rsi < rsi_threshold
+    cond_bb = close <= bb.lower
+    cond_vol = aligned_volume >= (rolling_volume * volume_multiplier)
+
+    entries = (cond_rsi & cond_bb & cond_vol).fillna(False)
+    exits = _compute_time_based_exits(entries, hold_days)
+
+    return StrategySignals(
+        symbol="",
+        timeframe="",
+        entries=entries.astype(bool),
+        exits=exits,
+        stop_loss=DEFAULT_EXECUTION_CONFIG.stop_loss,
+        take_profit=DEFAULT_EXECUTION_CONFIG.primary_take_profit(),
+    )
+
+
+class StrategyCore:
+    """High-level orchestrator for candidate selection and signal generation."""
+
+    def __init__(
+        self,
+        trading_config: TradingConfig = DEFAULT_TRADING_CONFIG,
+        execution_config: ExecutionConfig = DEFAULT_EXECUTION_CONFIG,
+        runtime_config: StrategyRuntimeConfig = DEFAULT_RUNTIME_CONFIG,
+        factor_loader: Optional[FactorScoreLoader] = None,
+    ) -> None:
+        self.trading_config = trading_config
+        self.execution_config = execution_config
+        self.runtime_config = runtime_config
+        self.factor_loader = factor_loader or FactorScoreLoader(runtime_config)
+
+    def select_candidates(
+        self,
+        universe: Iterable[str],
+        timeframe: Optional[str] = None,
+        top_n: Optional[int] = None,
+    ) -> List[str]:
+        """Select candidate symbols based on aggregated factor scores."""
+
+        timeframe_to_use = timeframe or self.runtime_config.default_timeframe
+        score_series = self.factor_loader.load_scores_as_series(
+            universe, timeframe=timeframe_to_use, top_n=5, agg="mean"
+        )
+        if score_series.empty:
+            return []
+
+        limit = top_n or self.trading_config.max_positions
+        selected = score_series.head(limit).index.tolist()
+        return selected
+
+    def generate_signals_for_symbol(
+        self,
+        symbol: str,
+        timeframe: str,
+        close: pd.Series,
+        volume: pd.Series,
+    ) -> StrategySignals:
+        """Create strategy signals for a single symbol."""
+
+        signal_bundle = hk_reversal_logic(
+            close=close,
+            volume=volume,
+            hold_days=self.trading_config.hold_days,
+        )
+        return StrategySignals(
+            symbol=symbol,
+            timeframe=timeframe,
+            entries=signal_bundle.entries,
+            exits=signal_bundle.exits,
+            stop_loss=self.execution_config.stop_loss,
+            take_profit=self.execution_config.primary_take_profit(),
+        )
+
+    def build_signal_universe(
+        self, price_data: Mapping[str, pd.DataFrame], timeframe: Optional[str] = None
+    ) -> Dict[str, StrategySignals]:
+        """Generate signals for the selected candidate universe."""
+
+        if not price_data:
+            return {}
+
+        universe = list(price_data.keys())
+        candidates = self.select_candidates(universe, timeframe=timeframe)
+        signals: Dict[str, StrategySignals] = {}
+        for symbol in candidates:
+            data = price_data[symbol]
+            if "close" not in data or "volume" not in data:
+                continue
+            signals[symbol] = self.generate_signals_for_symbol(
+                symbol=symbol,
+                timeframe=timeframe or self.runtime_config.default_timeframe,
+                close=data["close"],
+                volume=data["volume"],
+            )
+        return signals
+
+
+__all__ = ["StrategyCore", "StrategySignals", "hk_reversal_logic"]


### PR DESCRIPTION
## Summary
- implement trading, execution, and runtime configuration objects for the HK mid-frequency stack
- add factor score loading, strategy signal generation, and vectorbt backtest orchestration modules
- provide review utilities and expose the package exports for downstream use
- document the hk_midfreq package layout and usage workflow in a dedicated README

## Testing
- python -m compileall hk_midfreq

------
https://chatgpt.com/codex/tasks/task_e_68e0bc7be054832ab72b12d65ca42321