### PR TITLE
feat: orchestrate multi-timeframe factor fusion

### DIFF
--- a/hk_midfreq/__init__.py
+++ b/hk_midfreq/__init__.py
@@ -1,6 +1,6 @@
 """Public exports for the HK mid-frequency strategy package."""
 
-from hk_midfreq import backtest_engine, factor_interface, review_tools, strategy_core
+from hk_midfreq import backtest_engine, factor_interface, fusion, review_tools, strategy_core
 from hk_midfreq.backtest_engine import (
     BacktestArtifacts,
     run_portfolio_backtest,
@@ -14,16 +14,14 @@ from hk_midfreq.config import (
     StrategyRuntimeConfig,
     TradingConfig,
 )
-from hk_midfreq.factor_interface import (
-    FactorScoreLoader,
-    SymbolScore,
-    load_factor_scores,
-)
+from hk_midfreq.factor_interface import FactorScoreLoader, SymbolScore, load_factor_scores
+from hk_midfreq.fusion import FactorFusionEngine, FusedScores
 from hk_midfreq.strategy_core import StrategyCore, StrategySignals, hk_reversal_logic
 
 __all__ = [
     "backtest_engine",
     "factor_interface",
+    "fusion",
     "review_tools",
     "strategy_core",
     "BacktestArtifacts",
@@ -38,6 +36,8 @@ __all__ = [
     "FactorScoreLoader",
     "SymbolScore",
     "load_factor_scores",
+    "FactorFusionEngine",
+    "FusedScores",
     "StrategyCore",
     "StrategySignals",
     "hk_reversal_logic",

--- a/hk_midfreq/config.py
+++ b/hk_midfreq/config.py
@@ -4,9 +4,45 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence, Tuple
 
 DEFAULT_TAKE_PROFITS = (0.006, 0.01, 0.014, 0.018)
+
+
+@dataclass(frozen=True)
+class FusionConfig:
+    """Parameters governing how multi-timeframe factor scores are fused."""
+
+    factor_weighting: str = "ic_weighted"
+    timeframe_weights: Mapping[str, float] = field(
+        default_factory=lambda: {
+            "daily": 0.5,
+            "60min": 0.3,
+            "15min": 0.2,
+        }
+    )
+    trend_timeframe: str = "daily"
+    confirmation_timeframe: str = "60min"
+    intraday_timeframes: Tuple[str, ...] = ("15min", "5min")
+    trend_threshold: float = 0.0
+    confirmation_threshold: float = 0.0
+
+    def ordered_timeframes(self) -> Tuple[str, ...]:
+        """Return the unique timeframes required by the fusion rules."""
+
+        ordered: list[str] = []
+        for tf in (
+            self.trend_timeframe,
+            self.confirmation_timeframe,
+            *self.intraday_timeframes,
+        ):
+            if tf and tf not in ordered:
+                ordered.append(tf)
+        # Include any explicitly weighted timeframes so the loader can fetch them
+        for tf in self.timeframe_weights.keys():
+            if tf and tf not in ordered:
+                ordered.append(tf)
+        return tuple(ordered)
 
 
 @dataclass(frozen=True)
@@ -48,6 +84,9 @@ class StrategyRuntimeConfig:
     strategy_name: str = "HK_MIDFREQ_REVERSAL"
     base_output_dir: Path = Path("因子筛选")
     default_timeframe: str = "60min"
+    fusion: FusionConfig = field(default_factory=FusionConfig)
+    trend_ma_window: int = 20
+    confirmation_ma_window: int = 10
 
 
 DEFAULT_TRADING_CONFIG = TradingConfig()

--- a/hk_midfreq/fusion.py
+++ b/hk_midfreq/fusion.py
@@ -1,0 +1,125 @@
+"""Helper utilities to fuse factor scores across multiple timeframes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from hk_midfreq.config import DEFAULT_RUNTIME_CONFIG, StrategyRuntimeConfig
+
+
+@dataclass(frozen=True)
+class FusedScores:
+    """Container describing the composite factor view for a symbol."""
+
+    symbol: str
+    timeframe_scores: pd.Series
+    composite_score: float
+
+
+class FactorFusionEngine:
+    """Fuse per-factor panels into composite scores for each symbol."""
+
+    def __init__(
+        self,
+        runtime_config: StrategyRuntimeConfig = DEFAULT_RUNTIME_CONFIG,
+    ) -> None:
+        self._config = runtime_config
+
+    def _select_score_column(self, frame: pd.DataFrame) -> str:
+        if "comprehensive_score" in frame.columns:
+            return "comprehensive_score"
+        if "predictive_score" in frame.columns:
+            return "predictive_score"
+        raise KeyError("No supported score column present in factor frame")
+
+    def _factor_weights(self, frame: pd.DataFrame) -> pd.Series:
+        method = self._config.fusion.factor_weighting.lower()
+        if method == "ic_weighted" and "mean_ic" in frame.columns:
+            weights = frame["mean_ic"].abs()
+        else:
+            weights = pd.Series(1.0, index=frame.index)
+
+        if weights.sum() == 0:
+            weights = pd.Series(1.0, index=frame.index)
+        return weights / weights.sum()
+
+    def _aggregate_timeframe(self, frame: pd.DataFrame) -> float:
+        if frame.empty:
+            return np.nan
+
+        score_column = self._select_score_column(frame)
+        weights = self._factor_weights(frame)
+        aligned_scores = frame[score_column].reindex(weights.index).astype(float)
+        return float((aligned_scores * weights).sum())
+
+    def _combine_timeframes(self, scores: pd.Series) -> float:
+        fusion_cfg = self._config.fusion
+
+        trend_tf = fusion_cfg.trend_timeframe
+        if trend_tf:
+            trend_score = scores.get(trend_tf)
+            if pd.notna(trend_score) and trend_score < fusion_cfg.trend_threshold:
+                return np.nan
+
+        confirmation_tf = fusion_cfg.confirmation_timeframe
+        if confirmation_tf:
+            confirmation_score = scores.get(confirmation_tf)
+            if pd.notna(confirmation_score) and confirmation_score < fusion_cfg.confirmation_threshold:
+                return np.nan
+
+        weights = pd.Series(fusion_cfg.timeframe_weights, dtype=float)
+        weights = weights[weights.index.isin(scores.index)]
+        available_scores = scores[weights.index].dropna()
+        if available_scores.empty:
+            return np.nan
+        weights = weights[available_scores.index]
+        total = float(weights.sum())
+        if total == 0.0:
+            return float(available_scores.mean())
+        normalized = weights / total
+        return float((available_scores * normalized).sum())
+
+    def fuse(self, panel: pd.DataFrame) -> pd.DataFrame:
+        """Aggregate a factor panel into per-symbol composite scores."""
+
+        if panel.empty:
+            return pd.DataFrame()
+        if not isinstance(panel.index, pd.MultiIndex) or panel.index.nlevels < 3:
+            raise ValueError(
+                "Factor panel must be indexed by (symbol, timeframe, factor_name)."
+            )
+
+        grouped = panel.groupby(level=["symbol", "timeframe"], sort=False)
+        timeframe_scores = grouped.apply(self._aggregate_timeframe)
+        timeframe_scores.name = "score"
+        timeframe_matrix = timeframe_scores.unstack(level="timeframe")
+
+        composite = timeframe_matrix.apply(self._combine_timeframes, axis=1)
+        timeframe_matrix["composite_score"] = composite
+        return timeframe_matrix.sort_values(by="composite_score", ascending=False)
+
+    def fuse_symbol(self, panel: pd.DataFrame, symbol: str) -> Optional[FusedScores]:
+        """Convenience accessor returning ``FusedScores`` for a single symbol."""
+
+        if panel.empty:
+            return None
+        try:
+            symbol_frame = panel.xs(symbol, level="symbol")
+        except KeyError:
+            return None
+
+        grouped = symbol_frame.groupby(level="timeframe", sort=False)
+        timeframe_scores = grouped.apply(self._aggregate_timeframe)
+        composite = self._combine_timeframes(timeframe_scores)
+        return FusedScores(
+            symbol=symbol,
+            timeframe_scores=timeframe_scores,
+            composite_score=composite,
+        )
+
+
+__all__ = ["FactorFusionEngine", "FusedScores"]


### PR DESCRIPTION
## Problem
- Integrate professional screener outputs with multi-timeframe factor fusion and downstream execution.

## Summary
- Flatten top_factors_detailed artifacts into reusable symbol/timeframe factor panels.
- Add a fusion engine and runtime knobs to weight factors and gate candidates across daily/hourly/intraday views.
- Teach StrategyCore and the backtest engine to work with nested multi-frequency OHLCV data and document the workflow.

## Testing
- python -m compileall hk_midfreq

------
https://chatgpt.com/codex/tasks/task_e_68e0f7ac53f8832a9e9968971f8719a8