### PR TITLE
docs: add october 2025 hk midfreq audit

### DIFF
--- a/hk_midfreq/AUDIT_20251004.md
+++ b/hk_midfreq/AUDIT_20251004.md
@@ -1,0 +1,26 @@
+# HK Mid-Frequency Stack – October 2025 Audit
+
+## Current State
+- The strategy core still emits signals through the static RSI/Bollinger/volume reversal helper, so screened factors never influence trade timing. The generator returns `StrategySignals` derived from `hk_reversal_logic` without inspecting the panel captured in `_last_factor_panel`.【F:hk_midfreq/strategy_core.py†L104-L173】【F:hk_midfreq/strategy_core.py†L180-L235】
+- The comprehensive 0700 backtest script mirrors that fallback recipe. Even when the caller provides factor names and weights, the routine simply gates entries on RSI/Bollinger/volume and applies a random mask, so “factor-driven” backtests continue to trade once per period at most.【F:hk_midfreq/comprehensive_0700_backtest.py†L102-L160】
+- The HK resampling utility is still hard-wired to a developer machine path (`/Users/zhangshenshen/...`) for imports and raw/output directories, preventing other environments from generating the parquet set the backtests expect.【F:batch_resample_hk.py†L12-L59】
+- The standalone data scripts disagree on timeframe identifiers: the resampler writes 1-hour files with the `_1h_` suffix, while the comprehensive backtest loader looks for `_60m_` files. Running the analysis therefore raises `FileNotFoundError` even when the resampled data exists.【F:hk_midfreq/comprehensive_0700_backtest.py†L108-L115】【F:batch_resample_hk.py†L31-L76】
+
+## Remediation Plan
+1. **Align timeframe identifiers**
+   Decide on a canonical label (`60m` vs `1h`) and update both the resampler outputs and the loaders (including `Comprehensive0700Backtester.timeframe_mapping`) so that the file discovery logic matches the generated parquet names. Add an integration test that loads each timeframe end-to-end.
+
+2. **Wire factor outputs into signal generation**  
+   Extend `StrategyCore.generate_signals_for_symbol` to accept the ranked factor payload for the selected symbol/timeframe. Surface a signal builder that can ingest factor values (e.g., StochRSI series from the screening cache) and translate them into deterministic entry/exit events. Keep the current RSI/Bollinger recipe as a fallback when factor data is unavailable.
+
+3. **Refactor comprehensive backtests to consume factor signals**  
+   Replace the random mask shortcut with deterministic logic that reads the actual factor parquet/JSON outputs. Ensure the standalone script reuses the same factor-aware helper introduced in step 2 so manual analyses and the production pipeline stay aligned.
+
+4. **Parameterize HK resampling paths**  
+   Swap the absolute filesystem references in `batch_resample_hk.py` for CLI arguments or environment-driven defaults, guard the optional import of `HKResampler`, and update `docs/` with usage instructions so other developers can regenerate the intraday dataset.
+
+5. **Add regression coverage**  
+   Backfill unit tests under `hk_midfreq/tests/` to assert that (a) factor-informed signals produce trades when the factor threshold is crossed and (b) the resampler resolves paths from configurable inputs. Hook these into `make test` to prevent regressions.
+
+## Next Steps
+Execute items 1–4 in order of urgency, then schedule time for the new test coverage. Share updated usage docs with the data team once the resampling script ships.


### PR DESCRIPTION
## Summary
- add an October 2025 audit note covering current HK mid-frequency issues and remediation plan

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0f7e12998832aa04729de654006d0