### PR TITLE
feat: align hk midfreq factor pipeline

### DIFF
--- a/hk_midfreq/AUDIT_20251004.md
+++ b/hk_midfreq/AUDIT_20251004.md
@@ -1,0 +1,26 @@
+# HK Mid-Frequency Stack – October 2025 Audit
+
+## Current State
+- The strategy core still emits signals through the static RSI/Bollinger/volume reversal helper, so screened factors never influence trade timing. The generator returns `StrategySignals` derived from `hk_reversal_logic` without inspecting the panel captured in `_last_factor_panel`.【F:hk_midfreq/strategy_core.py†L104-L173】【F:hk_midfreq/strategy_core.py†L180-L235】
+- The comprehensive 0700 backtest script mirrors that fallback recipe. Even when the caller provides factor names and weights, the routine simply gates entries on RSI/Bollinger/volume and applies a random mask, so “factor-driven” backtests continue to trade once per period at most.【F:hk_midfreq/comprehensive_0700_backtest.py†L102-L160】
+- The HK resampling utility is still hard-wired to a developer machine path (`/Users/zhangshenshen/...`) for imports and raw/output directories, preventing other environments from generating the parquet set the backtests expect.【F:batch_resample_hk.py†L12-L59】
+- The standalone data scripts disagree on timeframe identifiers: the resampler writes 1-hour files with the `_1h_` suffix, while the comprehensive backtest loader looks for `_60m_` files. Running the analysis therefore raises `FileNotFoundError` even when the resampled data exists.【F:hk_midfreq/comprehensive_0700_backtest.py†L108-L115】【F:batch_resample_hk.py†L31-L76】
+
+## Remediation Plan
+1. **Align timeframe identifiers**
+   Decide on a canonical label (`60m` vs `1h`) and update both the resampler outputs and the loaders (including `Comprehensive0700Backtester.timeframe_mapping`) so that the file discovery logic matches the generated parquet names. Add an integration test that loads each timeframe end-to-end.
+
+2. **Wire factor outputs into signal generation**  
+   Extend `StrategyCore.generate_signals_for_symbol` to accept the ranked factor payload for the selected symbol/timeframe. Surface a signal builder that can ingest factor values (e.g., StochRSI series from the screening cache) and translate them into deterministic entry/exit events. Keep the current RSI/Bollinger recipe as a fallback when factor data is unavailable.
+
+3. **Refactor comprehensive backtests to consume factor signals**  
+   Replace the random mask shortcut with deterministic logic that reads the actual factor parquet/JSON outputs. Ensure the standalone script reuses the same factor-aware helper introduced in step 2 so manual analyses and the production pipeline stay aligned.
+
+4. **Parameterize HK resampling paths**  
+   Swap the absolute filesystem references in `batch_resample_hk.py` for CLI arguments or environment-driven defaults, guard the optional import of `HKResampler`, and update `docs/` with usage instructions so other developers can regenerate the intraday dataset.
+
+5. **Add regression coverage**  
+   Backfill unit tests under `hk_midfreq/tests/` to assert that (a) factor-informed signals produce trades when the factor threshold is crossed and (b) the resampler resolves paths from configurable inputs. Hook these into `make test` to prevent regressions.
+
+## Next Steps
+Execute items 1–4 in order of urgency, then schedule time for the new test coverage. Share updated usage docs with the data team once the resampling script ships.

--- a/hk_midfreq/__init__.py
+++ b/hk_midfreq/__init__.py
@@ -16,7 +16,13 @@ from hk_midfreq.config import (
 )
 from hk_midfreq.factor_interface import FactorScoreLoader, SymbolScore, load_factor_scores
 from hk_midfreq.fusion import FactorFusionEngine, FusedScores
-from hk_midfreq.strategy_core import StrategyCore, StrategySignals, hk_reversal_logic
+from hk_midfreq.strategy_core import (
+    FactorDescriptor,
+    StrategyCore,
+    StrategySignals,
+    generate_factor_signals,
+    hk_reversal_logic,
+)
 from hk_midfreq.review_tools import print_review, compile_review, portfolio_statistics, trade_overview
 
 __all__ = [
@@ -41,6 +47,8 @@ __all__ = [
     "FusedScores",
     "StrategyCore",
     "StrategySignals",
+    "FactorDescriptor",
+    "generate_factor_signals",
     "hk_reversal_logic",
     "print_review",
     "compile_review",

--- a/hk_midfreq/tests/test_factor_signals.py
+++ b/hk_midfreq/tests/test_factor_signals.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hk_midfreq.strategy_core import (  # noqa: E402
+    FactorDescriptor,
+    StrategyCore,
+    generate_factor_signals,
+)
+
+
+def _build_synthetic_prices(periods: int = 200) -> pd.Series:
+    index = pd.date_range("2024-01-01", periods=periods, freq="D")
+    values = 50 + np.sin(np.linspace(0, 12, periods)) * 5
+    return pd.Series(values, index=index, name="close")
+
+
+def test_generate_factor_signals_produces_entries_and_exits() -> None:
+    close = _build_synthetic_prices()
+    volume = pd.Series(1_000_000, index=close.index, name="volume")
+    descriptor = FactorDescriptor(
+        name="TA_STOCHRSI_fastd_period3_fastk_period5_timeperiod14_K",
+        timeframe="daily",
+    )
+
+    signals = generate_factor_signals(
+        symbol="0700.HK",
+        timeframe="daily",
+        close=close,
+        volume=volume,
+        descriptor=descriptor,
+        hold_days=5,
+        stop_loss=0.02,
+        take_profit=0.05,
+    )
+
+    assert signals.entries.index.equals(close.index)
+    assert signals.entries.any()
+    assert signals.exits.any()
+    assert signals.timeframe == "1day"
+
+
+def test_strategy_core_prefers_factor_driven_signals() -> None:
+    close = _build_synthetic_prices()
+    volume = pd.Series(1_000_000, index=close.index, name="volume")
+    frames = {"daily": pd.DataFrame({"close": close, "volume": volume})}
+
+    core = StrategyCore()
+    core._last_factor_panel = pd.DataFrame(
+        {
+            "rank": [1],
+            "comprehensive_score": [0.9],
+        },
+        index=pd.MultiIndex.from_tuples(
+            [
+                (
+                    "0700.HK",
+                    "daily",
+                    "TA_STOCHRSI_fastd_period3_fastk_period5_timeperiod14_K",
+                )
+            ],
+            names=["symbol", "timeframe", "factor_name"],
+        ),
+    )
+
+    signals = core.generate_signals_for_symbol("0700.HK", frames)
+    assert signals is not None
+    assert signals.entries.any()

--- a/hk_midfreq/tests/test_resampler_script.py
+++ b/hk_midfreq/tests/test_resampler_script.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from batch_resample_hk import batch_resample_all_1m  # noqa: E402
+
+
+def test_batch_resample_all_1m_produces_expected_outputs(tmp_path) -> None:
+    data_root = tmp_path / "hk_raw"
+    data_root.mkdir()
+
+    index = pd.date_range("2025-03-05 09:30", periods=120, freq="min")
+    base = np.linspace(50, 55, len(index))
+    frame = pd.DataFrame(
+        {
+            "open": base,
+            "high": base + 0.5,
+            "low": base - 0.5,
+            "close": base + 0.1,
+            "volume": np.full(len(index), 1_000_000),
+        },
+        index=index,
+    )
+    source = data_root / "0700HK_1m_2025-03-05_2025-03-05.parquet"
+    frame.to_parquet(source)
+
+    output_dir = tmp_path / "resampled"
+    result_dir = batch_resample_all_1m(
+        data_root=data_root,
+        output_dir=output_dir,
+        timeframes=["15m", "60m"],
+    )
+
+    assert result_dir == output_dir.resolve()
+
+    expected_15m = output_dir / "0700HK_15m_2025-03-05_2025-03-05.parquet"
+    expected_60m = output_dir / "0700HK_60m_2025-03-05_2025-03-05.parquet"
+
+    assert expected_15m.exists()
+    assert expected_60m.exists()
+
+    resampled_60m = pd.read_parquet(expected_60m)
+    assert not resampled_60m.empty
+    assert "close" in resampled_60m.columns


### PR DESCRIPTION
## Summary
- wire the HK strategy core to translate selected factors into deterministic StochRSI-driven signals with timeframe normalization and fallbacks
- refactor the comprehensive 0700 backtest workflow to reuse the factor-aware helper, align timeframe labels, and remove random masking from multi-factor paths
- replace the HK resampling script with a configurable entry point and add regression tests covering factor signals and the resampler CLI

## Testing
- pytest hk_midfreq/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e0f7e12998832aa04729de654006d0